### PR TITLE
Tweak template

### DIFF
--- a/resources/leiningen/new/shadow_cljs/deps.cljs
+++ b/resources/leiningen/new/shadow_cljs/deps.cljs
@@ -1,3 +1,0 @@
-{:npm-deps {:create-react-class "15.6.2"
-            :react              "^16.0.0"
-            :react-dom          "^16.0.0"}}

--- a/resources/leiningen/new/shadow_cljs/index.html
+++ b/resources/leiningen/new/shadow_cljs/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="css/style.css" rel="stylesheet" type="text/css">
+    <link href="/css/style.css" rel="stylesheet" type="text/css">
     <link rel="icon" href="https://clojurescript.org/images/cljs-logo-icon-32.png">
   </head>
   <body>
     <div id="app">
       Shadow-cljs rocks!
     </div>
-    <script src="js/compiled/main.js" type="text/javascript"></script>
+    <script src="/js/compiled/main.js" type="text/javascript"></script>
     <script>{{name}}.core.init();</script>
   </body>
 </html>

--- a/resources/leiningen/new/shadow_cljs/om/core.cljs
+++ b/resources/leiningen/new/shadow_cljs/om/core.cljs
@@ -1,9 +1,7 @@
 (ns {{name}}.core
     (:require [goog.dom :as gdom]
-              [om.next :as om :refer-macros [defui]]
+              [om.next :as om :refer [defui]]
               [om.dom :as dom]))
-
-(enable-console-print!)
 
 (defui HelloWorld
   Object

--- a/resources/leiningen/new/shadow_cljs/om/shadow-cljs.edn
+++ b/resources/leiningen/new/shadow_cljs/om/shadow-cljs.edn
@@ -3,7 +3,6 @@
  ["src"]
 
  :dependencies [[binaryage/devtools "0.9.7"]
-                [thheller/shadow-cljsjs "0.0.3"]
                 ;; fork to support react 16
                 [com.tiensonqin/om "1.0.0-beta2-SNAPSHOT"]]
 

--- a/resources/leiningen/new/shadow_cljs/package.json
+++ b/resources/leiningen/new/shadow_cljs/package.json
@@ -1,16 +1,15 @@
 {
   "scripts": {
-    "deps": "yarn install; shadow-cljs npm-deps;",
+    "deps": "yarn install",
     "watch": "shadow-cljs watch app;",
     "release": "shadow-cljs release app;",
     "server": "shadow-cljs server;",
     "clean": "rm -rf target; rm -rf public/js/compiled"
   },
   "dependencies": {
-    "@cljs-oss/module-deps": "^1.1.1",
     "create-react-class": "^15.6.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "shadow-cljs": "2.0.77"
+    "shadow-cljs": "^2.0.80"
   }
 }

--- a/resources/leiningen/new/shadow_cljs/reagent/core.cljs
+++ b/resources/leiningen/new/shadow_cljs/reagent/core.cljs
@@ -1,8 +1,6 @@
 (ns {{name}}.core
   (:require [reagent.core :as reagent :refer [atom]]))
 
-(enable-console-print!)
-
 ;; define your app data so that it doesn't get over-written on reload
 
 (defonce app-state (atom {:text "Hello world!"}))

--- a/resources/leiningen/new/shadow_cljs/reagent/shadow-cljs.edn
+++ b/resources/leiningen/new/shadow_cljs/reagent/shadow-cljs.edn
@@ -3,7 +3,6 @@
  ["src"]
 
  :dependencies [[binaryage/devtools "0.9.7"]
-                [thheller/shadow-cljsjs "0.0.3"]
                 [reagent "0.8.0-alpha2"]]
 
  ;; set an nrepl port for connection to a REPL.

--- a/resources/leiningen/new/shadow_cljs/rum/core.cljs
+++ b/resources/leiningen/new/shadow_cljs/rum/core.cljs
@@ -1,8 +1,6 @@
 (ns {{name}}.core
   (:require [rum.core :as rum]))
 
-(enable-console-print!)
-
 (defonce app-state (atom {:text "Hello world!"}))
 
 (rum/defc hello-world []

--- a/resources/leiningen/new/shadow_cljs/rum/shadow-cljs.edn
+++ b/resources/leiningen/new/shadow_cljs/rum/shadow-cljs.edn
@@ -3,7 +3,6 @@
  ["src"]
 
  :dependencies [[binaryage/devtools "0.9.7"]
-                [thheller/shadow-cljsjs "0.0.3"]
                 ;; fork to support react 16
                 [ua.modnakasta/rum "0.11.0-2"]
                 [org.roman01la/citrus "3.0.0" :exclusions [rum]]]

--- a/src/leiningen/new/shadow_cljs.clj
+++ b/src/leiningen/new/shadow_cljs.clj
@@ -26,8 +26,7 @@
         data {:name name
               :sanitized (name-to-path name)}]
     (->>
-     [["deps.cljs" (raw "deps.cljs")]
-      ["package.json" (raw "package.json")]
+     [["package.json" (raw "package.json")]
       ["README.md" (raw "README.md")]
       ["public/index.html" (render "index.html" data)]
       ["public/css/style.css" (raw "style.css")]


### PR DESCRIPTION
- `deps.cljs` is not used.
- use absolute paths for css/js so reloading works properly
- `(enable-console-print!)` is injected by the compiler, no need to call it.
- `thheller/shadow-cljsjs` is provided automatically